### PR TITLE
Appveyor: fix debug, use poppler, compress with 7z [ci skip]

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,11 +7,13 @@ environment:
       QTLIBS: Qt5CLucene Qt5Core Qt5Gui Qt5Help Qt5Network Qt5PrintSupport Qt5Sql Qt5Widgets Qt5Xml
 
   matrix:
-    - ENGAUGE_RELEASE: "1"
+    - ENGAUGE_RELEASE: 1
+      ENGAUGE_CONFIG: "pdf"
       QTLIBEXT: '.lib'
       LOG4CPPDLLINK: 'https://dl.dropboxusercontent.com/u/1147076/log4cpp-1.1.1.zip'
       RESULTDIR: engauge-build
-    - QTLIBEXT: 'd.lib'
+    - ENGAUGE_CONFIG: "debug pdf"
+      QTLIBEXT: 'd.lib'
       LOG4CPPDLLINK: 'https://dl.dropboxusercontent.com/u/1147076/log4cpp-debug-1.1.1.zip'
       RESULTDIR: engauge-build-debug
 
@@ -34,12 +36,17 @@ install:
   - move *dll lib
   - move *def lib
   - move *lib lib
+  - cd %APPVEYOR_BUILD_FOLDER%
+  - curl -fsSLO 'https://dl.dropboxusercontent.com/u/1147076/poppler-qt5.zip' -o poppler-qt5.zip
+  - 7z x poppler-qt5.zip -aoa
 
 build_script:
   - cd %APPVEYOR_BUILD_FOLDER%
   - set LOG4CPP_HOME=%APPVEYOR_BUILD_FOLDER%\log4cpp-1.1.1
   - set FFTW_HOME=%APPVEYOR_BUILD_FOLDER%\fftw-3.3.4-dll32
-  - qmake engauge.pro
+  - set POPPLER_INCLUDE=%APPVEYOR_BUILD_FOLDER%\poppler-qt5\include\poppler\qt5
+  - set POPPLER_LIB=%APPVEYOR_BUILD_FOLDER%\poppler-qt5
+  - qmake engauge.pro "CONFIG+=%ENGAUGE_CONFIG%"
   - move Makefile Makefile.orig
   - ps: gc Makefile.orig | %{ $_ -replace '551.lib', $Env:QTLIBEXT } > Makefile
   - nmake
@@ -61,14 +68,15 @@ after_build:
   - copy bin\engauge.exe %RESULTDIR%
   - copy log4cpp-1.1.1\lib\log4cpp.dll %RESULTDIR%
   - copy fftw-3.3.4-dll32\lib\libfftw3-3.dll %RESULTDIR%
+  - copy %APPVEYOR_BUILD_FOLDER%\poppler-qt5\*.dll %RESULTDIR%
   - copy LICENSE %RESULTDIR%
   - cd %APPVEYOR_BUILD_FOLDER%\help
   - qcollectiongenerator engauge.qhcp -o engauge.qhc
   - move engauge.qch ..\%RESULTDIR%\documentation
   - move engauge.qhc ..\%RESULTDIR%\documentation
   - cd ..
-  - 7z a %RESULTDIR%.zip %RESULTDIR%
+  - 7z a %RESULTDIR%.7z %RESULTDIR%
 
 artifacts:
-  - path: engauge-build*.zip
+  - path: engauge-build*.7z
     name: engauge-build-result

--- a/engauge.pro
+++ b/engauge.pro
@@ -758,7 +758,7 @@ pdf {
       }
     }
     DEFINES += "ENGAUGE_PDF"
-    LIBS += -L$$(POPPLER_LIB) -lpoppler -lpoppler-qt5
+    LIBS += -L$$(POPPLER_LIB) -lpoppler-qt5
     INCLUDEPATH += $$(POPPLER_INCLUDE)
     HEADERS += src/Pdf/Pdf.h
     SOURCES += src/Pdf/Pdf.cpp


### PR DESCRIPTION
Fix debug build with recent changes to project file. ENGAUGE_RELEASE left for convenience.
Use self-built poppler-qt5 library for PDF import. TODO: Update poppler dependencies. Extra dlls added to bundle.
Compress resulting artifcact with 7z for reduced size.