### PR TITLE
Added default location on linux systems to list of help file locations

### DIFF
--- a/src/Help/HelpWindow.cpp
+++ b/src/Help/HelpWindow.cpp
@@ -67,6 +67,7 @@ QString HelpWindow::helpPath() const
 #endif
   paths << "/documentation/engauge.qhc";
   paths << "/../share/doc/engauge-digitizer/engauge.qhc";
+  paths << "/usr/share/engauge-digitizer-doc/engauge.qhc";
 
   QStringList::iterator itr;
   for (itr = paths.begin(); itr != paths.end(); itr++) {


### PR DESCRIPTION
Hi,

on some linux distributions installation of the helpfile is expected under /usr/share/engauge-digitizer-doc/engauge.qhc .  For the debian packages I thus add this via a patch, but it might be helpful 
for other distributions to include the additional search path by default.

Cheers,

Tobi