### PR TITLE
Revert "Switch appveyor builds to Visual Studio 2015."

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 init:
-  - C:\"Program Files (x86)"\"Microsoft Visual Studio 14.0"\VC\vcvarsall.bat x86
+  - C:\"Program Files (x86)"\"Microsoft Visual Studio 12.0"\VC\vcvarsall.bat x86
 
 environment:
   global:
@@ -9,18 +9,18 @@ environment:
   matrix:
     - ENGAUGE_RELEASE: 1
       ENGAUGE_CONFIG: "pdf"
-      VCLIBS: MSVCP140.dll VCRUNTIME140.dll
+      VCLIBS: MSVCP120.DLL MSVCR120.DLL
       LOG4CPPFILE: 'dev\windows\appveyor\log4cpp-1.1.1.zip'
       POPPLERQT5FILE: 'dev\windows\appveyor\poppler-qt5-0.48.0.zip'
       RESULTDIR: engauge-build
     - ENGAUGE_CONFIG: "debug pdf"
-      VCLIBS: MSVCP140D.dll VCRUNTIME140D.dll 
+      VCLIBS: MSVCP120D.DLL MSVCR120D.DLL
       LOG4CPPFILE: 'dev\windows\appveyor\log4cpp-debug-1.1.1.zip'
       POPPLERQT5FILE: 'dev\windows\appveyor\poppler-qt5-debug-0.48.0.zip'
       RESULTDIR: engauge-build-debug
 
 install:
-  - set QTDIR=C:\Qt\5.8\msvc2015
+  - set QTDIR=C:\Qt\5.8\msvc2013
   - set PATH=%PATH%;%QTDIR%\bin
   - cd %APPVEYOR_BUILD_FOLDER%
   - 7z x %APPVEYOR_BUILD_FOLDER%\%LOG4CPPFILE% -aoa


### PR DESCRIPTION
Reverts markummitchell/engauge-digitizer#213

I am reverting this to make master branch builds workable, until we have correct log4cpp and poppler-qt5 versions in place (soon).