### PR TITLE
Check on !mac instead of other archs to decide on inclusion of help

### DIFF
--- a/engauge.pro
+++ b/engauge.pro
@@ -35,7 +35,7 @@
 
 QT += core gui printsupport widgets xml
 
-win32-*|linux-*|unix-* {
+!mac {
 QT += help
 HEADERS += src/Help/HelpBrowser.h \
            src/Help/HelpWindow.h


### PR DESCRIPTION
In the code the check is also on !OSX. Thus the code fails to compile on
architectures not in the list as e.g. kFreeBSD or HURD.