### PR TITLE
Add missing include.

### DIFF
--- a/src/Load/LoadImageFromUrl.cpp
+++ b/src/Load/LoadImageFromUrl.cpp
@@ -10,6 +10,7 @@
 #include <QFileInfo>
 #include <QMessageBox>
 #include <QtNetwork/QNetworkReply>
+#include <QTextStream>
 #include <QUrl>
 #include "Version.h"
 


### PR DESCRIPTION
Under certain conditions it seems to [fail to build](https://662476.bugs.gentoo.org/attachment.cgi?id=541764) with Qt 5.11.