### PR TITLE
Fix .lgtm.yml for LGTM.com C/C++ analysis

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -3,15 +3,7 @@ extraction:
     prepare:
       packages:
         - qt5-qmake
-        - qtbase5-dev-tools
-        - libfftw3-dev
-	- libjpeg-dev
-	- liblog4cpp5-dev
-	- libpng12-dev
     configure:
       command:
       - qmake engauge.pro
-    index:
-      build_command:
-        - make
 	

--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,9 +1,5 @@
 extraction:
   cpp:
-    prepare:
-      packages:
-        - qt5-qmake
     configure:
       command:
       - qmake engauge.pro
-	


### PR DESCRIPTION
I noticed that your `.lgtm.yml` file resulted in a build error on LGTM.com, so I had a quick look to fix it. The main issue was the use of a combination of tabs and spaces for indentation.

There's no need to install all the Debian package dependencies: these are automatically installed (curious how? There's a [blog post](https://lgtm.com/blog/how_lgtm_builds_cplusplus)). Additionally, LGTM automatically tries to run `make` if there's a `Makefile` (or similar) present, so no need to specify that either.

So, the only thing to explicitly specify in the `.lgtm.yml` is the `configure` command. Results for C/C++ analysis should appear on LGTM.com soon after this PR is merged.

(full disclosure: I'm part of the team that built LGTM)