### PR TITLE
Fix undefined behaviour in DlgSettingsColorFilter.cpp: use 'delete[]' instead of 'free'

### DIFF
--- a/src/Dlg/DlgSettingsColorFilter.cpp
+++ b/src/Dlg/DlgSettingsColorFilter.cpp
@@ -501,7 +501,7 @@ void DlgSettingsColorFilter::updateHistogram()
 
   }
 
-  free (histogramBins);
+  delete[] histogramBins;
 }
 
 void DlgSettingsColorFilter::updatePreview ()


### PR DESCRIPTION
Flagged up by LGTM.com: https://lgtm.com/projects/g/markummitchell/engauge-digitizer/snapshot/4fcbeb3655f7ab8c3984bd40db331483da55a505/files/src/Dlg/DlgSettingsColorFilter.cpp#xd275f2ca7c80cd4:1

Documentation: https://lgtm.com/rules/1506091336071/